### PR TITLE
fix: Make code consistent with ANALOG_RESOLUTION

### DIFF
--- a/include/config/configuration_controller.hpp
+++ b/include/config/configuration_controller.hpp
@@ -51,7 +51,7 @@ private:
             config.heKeys[i].upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
 
             // Set the calibration values to the outer boundaries of the possible values to "disable" them.
-            config.heKeys[i].restPosition = pow(2, ANALOG_RESOLUTION);
+            config.heKeys[i].restPosition = pow(2, ANALOG_RESOLUTION) - 1;
             config.heKeys[i].downPosition = 0;
         }
 

--- a/include/config/configuration_controller.hpp
+++ b/include/config/configuration_controller.hpp
@@ -27,7 +27,8 @@ private:
         Configuration config = {
             .name = {'m', 'i', 'n', 'i', 'p', 'a', 'd'},
             .heKeys = {},
-            .digitalKeys = {}};
+            .digitalKeys = {}
+        };
 
         // Populate the hall effect keys array with the correct amount of hall effect keys.
         for (uint8_t i = 0; i < HE_KEYS; i++)
@@ -49,9 +50,9 @@ private:
             config.heKeys[i].lowerHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.55);
             config.heKeys[i].upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
 
-            // Approximate calibration values on a 49E sensor with 12-bit resolution.
-            config.heKeys[i].restPosition = 1800;
-            config.heKeys[i].downPosition = 1100;
+            // Set the calibration values to the outer boundaries of the possible values to "disable" them.
+            config.heKeys[i].restPosition = pow(2, ANALOG_RESOLUTION);
+            config.heKeys[i].downPosition = 0;
         }
 
         // Populate the digital keys array with the correct amount of digital keys.

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -26,7 +26,7 @@
 // This value is important to reset the rapid trigger state properly with continuous rapid trigger.
 #define CONTINUOUS_RAPID_TRIGGER_THRESHOLD 10
 
-// The resolution for the ADCs on the RP2040. The maximum compatible value on it is 12 bit.
+// The resolution for the ADCs on the RP2040. The maximum compatible value on it is 16 bit.
 #define ANALOG_RESOLUTION 12
 
 // The exponent for the amount of samples for the SMA filter. This filter reduces fluctuation of analog values.

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -5,6 +5,10 @@
 #include "helpers/string_helper.hpp"
 #include "definitions.hpp"
 
+// Constant square of the ANALOG_RESOLUTION definition since calculating it every loop is too expensive.
+// Used to invert the read sensor value in case the INVERT_SENSOR_READINGS definition is set.
+const uint16_t ANALOG_RESOLUTION_SQUARED = pow(2, ANALOG_RESOLUTION);
+
 /*
    Explanation of the Rapid Trigger Logic
 
@@ -198,9 +202,8 @@ uint16_t KeypadHandler::readKey(const Key &key)
         // Invert the value if the definition is set since in rare fields of application the sensor
         // is mounted the other way around, resulting in a different polarity and inverted sensor readings.
         // Since this firmware expects the value to go down when the button is pressed down, this is needed.
-        // TODO: Replace 4095 with pow(2, ANALOG_RESOLUTION) - 1
 #ifdef INVERT_SENSOR_READINGS
-        value = 4095 - value;
+        value = ANALOG_RESOLUTION_SQUARED - 1 - value;
 #endif
 
         // Filter the value through the SMA filter and return it.


### PR DESCRIPTION
This PR removes some "magic numbers" related to the analog resolution and replaces it with a scaled variable based on the resolution.

- Constant `4095` when inverting sensor values was replaced with a pre-calculated `pow(2, ANALOG_RESOLUTION) - 1`
- Calibration values (rest and down) of the default configuration was set to `pow(2, ANALOG_RESOLUTION) - 1` and `0` respectively.