### PR TITLE
feat: add analog resolution (`ares`) to `get` command

### DIFF
--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -166,6 +166,7 @@ void SerialHandler::get()
     print("GET htol=%d", HYSTERESIS_TOLERANCE);
     print("GET rtol=%d", RAPID_TRIGGER_TOLERANCE);
     print("GET trdt=%d", TRAVEL_DISTANCE_IN_0_01MM);
+    print("GET ares=%d", ANALOG_RESOLUTION);
 
     // Output all hall effect key-specific settings.
     for (const HEKey &key : ConfigController.config.heKeys)


### PR DESCRIPTION
Adds the analog resolution to the `get` command output:
```cpp
print("GET ares=%d", ANALOG_RESOLUTION);
```