### PR TITLE
Prepare upcoming release `2023.516.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2023.516.1 - Digital key support!
+# 2023.516.1 - Digital key support, support for more keys!
 
 This release adds support for digital keys, which might not be useful for minipad owners *yet*, but is for people DIY-ing a keypad or messing around with the firmware, as well as the collaboratoring commercial products of the Minipad Project. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This release also prepares the communication with minitility, our configuration 
 
 - Added support for digital keys (push buttons, mechanical switches, ...)
 - Added debounce for digital keys with a default of 50ms
-- Made the amount of hall effect/digital keys fully dynamic, not limited to 2-3
+- Made the amount of hall effect/digital keys fully dynamic, not limited to 2-3 but rather limited to the hardware specifications of the RP2040 micro controller
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 2023.516.1 - Digital key support!
 
-some text here
+This release adds support for digital keys, which might not be useful for minipad owners *yet*, but is for people DIY-ing a keypad or messing around with the firmware, as well as the collaboratoring commercial products of the Minipad Project. 
+
+This release also prepares the communication with minitility, our configuration software which is coming closer to be ready to use.
 
 ## Features
 
@@ -15,7 +17,7 @@ some text here
 
 ## Changes
 
-- Migrated `ping` command to `get` command
+- Migrated info retrieved via the `ping` to the `get` command
 - Split the `key` identifier in the serial protocol into `hkey` (hall effect) and `dkey` (digital)
 - Changed the command for changing the key pressed from `key` to `char`
 - Removed config versions other than the main `Configuration` object, removed mutations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 2023.516.1 - Digital key support!
+
+some text here
+
+## Features
+
+- Added support for digital keys (push buttons, mechanical switches, ...)
+- Added debounce for digital keys with a default of 50ms
+- Made the amount of hall effect/digital keys fully dynamic, not limited to 2-3
+
+## Bug Fixes
+
+- Refactored `getArgumentAt` function
+- Fix `name` command not null-terminating
+
+## Changes
+
+- Migrated `ping` command to `get` command
+- Split the `key` identifier in the serial protocol into `hkey` (hall effect) and `dkey` (digital)
+- Removed config versions other than the main `Configuration` object, removed mutations
+- Switched from hardcoded pin arrays to a formula macro
+- Changed the default values for rest and down positions to 4095 and 0 respectively
+- Added definition for reversing the sensor values
+
 # 2023.410.1 - Initial release!
 
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ some text here
 
 - Migrated `ping` command to `get` command
 - Split the `key` identifier in the serial protocol into `hkey` (hall effect) and `dkey` (digital)
+- Changed the command for changing the key pressed from `key` to `char`
 - Removed config versions other than the main `Configuration` object, removed mutations
 - Switched from hardcoded pin arrays to a formula macro
 - Changed the default values for rest and down positions to 4095 and 0 respectively

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 // The version of this firmware in the YYYY.MDD.PATCH format. (e.g. 2022.1219.2 for the 2nd release on the 19th december 2022)
-#define FIRMWARE_VERSION "2023.410.1"
+#define FIRMWARE_VERSION "2023.516.1"
 
 // ┌───────────────────────────────────────────────────────────────────────────────────────────────────┐
 // │                                                                                                   │


### PR DESCRIPTION
Updates the firmware version definition, as well as adding the changes to the changelog markdown file.