### PR TITLE
qol: Default to development environments, introduce prod. envs

### DIFF
--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -74,5 +74,5 @@
 
 // If the debug flag is not set via compiler parameters, default it to 0 since it's required for if statements.
 #ifndef DEV
-#define dEV 0
+#define DEV 0
 #endif

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -71,3 +71,8 @@
 #if DIGITAL_KEYS > 26
 #error As of right now, the firmware only supports up to 26 digital keys.
 #endif
+
+// If the debug flag is not set via compiler parameters, default it to 0 since it's required for if statements.
+#ifndef DEV
+#define dEV 0
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = minipad-3k
+default_envs = minipad-3k-dev
 
 [env]
 platform = https://github.com/minipadKB/platform-raspberrypi.git
@@ -20,14 +20,6 @@ board_build.core = earlephilhower
 board_build.arduino.earlephilhower.usb_manufacturer=Project Minipad
 build_flags = -DUSBD_VID=0x0727 -DUSBD_PID=0x0727 -DHID_POLLING_RATE=1000 -DIGNORE_MULTI_ENDPOINT_PID_MUTATION -Wall -Wextra
 
-[env:minipad-2k]
-build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0 -DDEBUG=0
-board_build.arduino.earlephilhower.usb_product=minipad-2k
-
-[env:minipad-3k]
-build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0 -DDEBUG=0
-board_build.arduino.earlephilhower.usb_product=minipad-3k
-
 [env:minipad-2k-dev]
 build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0 -DDEBUG=1
 board_build.arduino.earlephilhower.usb_product=minipad-2k-dev
@@ -36,6 +28,10 @@ board_build.arduino.earlephilhower.usb_product=minipad-2k-dev
 build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0 -DDEBUG=1
 board_build.arduino.earlephilhower.usb_product=minipad-3k-dev
 
-[env:minipad-temp]
-build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=1 -DDEBUG=1
-board_build.arduino.earlephilhower.usb_product=minipad-temp
+[env:minipad-2k-prod]
+build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0 -DDEBUG=0
+board_build.arduino.earlephilhower.usb_product=minipad-2k
+
+[env:minipad-3k-prod]
+build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0 -DDEBUG=0
+board_build.arduino.earlephilhower.usb_product=minipad-3k

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,17 +21,17 @@ board_build.arduino.earlephilhower.usb_manufacturer=Project Minipad
 build_flags = -DUSBD_VID=0x0727 -DUSBD_PID=0x0727 -DHID_POLLING_RATE=1000 -DIGNORE_MULTI_ENDPOINT_PID_MUTATION -Wall -Wextra
 
 [env:minipad-2k-dev]
-build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0 -DDEBUG=1
+build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0 -DDEV=1
 board_build.arduino.earlephilhower.usb_product=minipad-2k-dev
 
 [env:minipad-3k-dev]
-build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0 -DDEBUG=1
+build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0 -DDEV=1
 board_build.arduino.earlephilhower.usb_product=minipad-3k-dev
 
 [env:minipad-2k-prod]
-build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0 -DDEBUG=0
+build_flags = ${env.build_flags} -DHE_KEYS=2 -DDIGITAL_KEYS=0
 board_build.arduino.earlephilhower.usb_product=minipad-2k
 
 [env:minipad-3k-prod]
-build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0 -DDEBUG=0
+build_flags = ${env.build_flags} -DHE_KEYS=3 -DDIGITAL_KEYS=0
 board_build.arduino.earlephilhower.usb_product=minipad-3k

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -42,7 +42,7 @@ void SerialHandler::handleSerialInput(String *inputStr)
         name(parameters);
     else if (isEqual(command, "out"))
         out(isTrue(arg0));
-#if DEBUG
+#ifdef DEV
     else if (isEqual(command, "echo"))
         echo(parameters);
 #endif

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -159,7 +159,7 @@ void SerialHandler::save()
 void SerialHandler::get()
 {
     // Output all global settings.
-    print("GET version=%s%s", FIRMWARE_VERSION, DEBUG ? "-dev" : "");
+    print("GET version=%s%s", FIRMWARE_VERSION, DEV ? "-dev" : "");
     print("GET hkeys=%d", HE_KEYS);
     print("GET dkeys=%d", DIGITAL_KEYS);
     print("GET name=%s", ConfigController.config.name);


### PR DESCRIPTION
This PR does three things:
1. It removes the normal "minipad-2k" and "minipad-3k" PIO environments and now defaults to the development environments.
2. It introduces production environments, meaning there is now the differentiation between the production firmware (official releases) and the development firmware (forks or local modifications people run on their keypad)
3. The DEBUG definition is replaced with the DEV definition as it is a more fitting name.

This improves the overall work experience with the repository and version management of the firmware. If you see a firmware version ending with "-dev" now, you can be sure they compiled it themeselves.