### PR TITLE
feat: Add single `out` output

### DIFF
--- a/include/handlers/key_states/he_key_state.hpp
+++ b/include/handlers/key_states/he_key_state.hpp
@@ -20,6 +20,9 @@ struct HEKeyState : KeyState
     // The last value read from the hall effect sensor.
     uint16_t lastSensorValue = 0;
 
+    // The mapped version of the value read from the hall effect sensor.
+    uint16_t lastMappedValue = 0;
+
     // The simple moving average filter for stabilizing the analog outpt.
     SMAFilter filter = SMAFilter(SMA_FILTER_SAMPLE_EXPONENT);
 };

--- a/include/handlers/key_states/he_key_state.hpp
+++ b/include/handlers/key_states/he_key_state.hpp
@@ -17,6 +17,9 @@ struct HEKeyState : KeyState
     // The current peak value for the rapid trigger logic.
     uint16_t rapidTriggerPeak = 65535;
 
+    // The last value read from the hall effect sensor.
+    uint16_t lastSensorValue = 0;
+
     // The simple moving average filter for stabilizing the analog outpt.
     SMAFilter filter = SMAFilter(SMA_FILTER_SAMPLE_EXPONENT);
 };

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -13,21 +13,21 @@ public:
     {
         // Initialize the hall effect key states with their default values.
         for (uint8_t i = 0; i < HE_KEYS; i++)
-            _heKeyStates[i] = HEKeyState();
+            heKeyStates[i] = HEKeyState();
 
         // Initialize the digital key states with their default values.
 #pragma GCC diagnostic ignored "-Wtype-limits"
         for (uint8_t i = 0; i < DIGITAL_KEYS; i++)
 #pragma GCC diagnostic pop
-            _digitalKeyStates[i] = DigitalKeyState();
+            digitalKeyStates[i] = DigitalKeyState();
     }
 
     void handle();
     bool outputMode;
+    HEKeyState heKeyStates[HE_KEYS];
+    DigitalKeyState digitalKeyStates[DIGITAL_KEYS];
 
 private:
-    HEKeyState _heKeyStates[HE_KEYS];
-    DigitalKeyState _digitalKeyStates[DIGITAL_KEYS];
 
     void checkHEKey(const HEKey &key, uint16_t value);
     void checkDigitalKey(const DigitalKey &key, bool pressed);

--- a/include/handlers/serial_handler.hpp
+++ b/include/handlers/serial_handler.hpp
@@ -6,6 +6,7 @@ inline class SerialHandler
 {
 public:
     void handleSerialInput(String *inputStr);
+    void printHEKeyOutput(const HEKey &key);
 
 private:
     void boot();

--- a/include/handlers/serial_handler.hpp
+++ b/include/handlers/serial_handler.hpp
@@ -13,7 +13,7 @@ private:
     void save();
     void get();
     void name(char *name);
-    void out(bool state);
+    void out(bool single, bool state);
     void echo(char *input);
     void hkey_rt(HEKey &key, bool state);
     void hkey_crt(HEKey &key, bool state);

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -207,7 +207,8 @@ uint16_t KeypadHandler::readKey(const Key &key)
 #endif
 
         // Filter the value through the SMA filter and return it.
-        return _heKeyStates[key.index].filter(value);
+        _heKeyStates[key.index].lastSensorValue = _heKeyStates[key.index].filter(value);
+        return _heKeyStates[key.index].lastSensorValue;
     }
     // Otherwise, in case anything goes wrong, default to 0.
     else

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -2,6 +2,7 @@
 #include <Keyboard.h>
 #include "config/keys/key_type.hpp"
 #include "handlers/keypad_handler.hpp"
+#include "handlers/serial_handler.hpp"
 #include "helpers/string_helper.hpp"
 #include "definitions.hpp"
 
@@ -61,15 +62,15 @@ void KeypadHandler::handle()
     for (const HEKey &key : ConfigController.config.heKeys)
     {
         // Read the value from the hall effect sensor and map it to the travel distance range.
-        uint16_t rawValue = readKey(key);
-        uint16_t mappedValue = mapSensorValueToTravelDistance(key, rawValue);
+        heKeyStates[key.index].lastSensorValue = readKey(key);
+        heKeyStates[key.index].lastMappedValue = mapSensorValueToTravelDistance(key, heKeyStates[key.index].lastSensorValue);
 
         // If the output mode is enabled, output the raw and mapped values.
         if (outputMode)
-            Serial.printf("OUT hkey%d=%d %d\n", key.index + 1, rawValue, mappedValue);
+            SerialHandler.printHEKeyOutput(key);
 
         // Run the checks on the HE key.
-        checkHEKey(key, mappedValue);
+        checkHEKey(key, heKeyStates[key.index].lastMappedValue);
     }
 
     // Go through all digital keys and run the checks.
@@ -108,44 +109,44 @@ void KeypadHandler::checkHEKey(const HEKey &key, uint16_t value)
     // meaning the rapid trigger state for the key has to be set to false in order to be processed by further checks.
     // This only applies if continuous rapid trigger is not enabled as it only resets the state when the key is fully released.
     if (value >= key.upperHysteresis && !key.continuousRapidTrigger)
-        _heKeyStates[key.index].inRapidTriggerZone = false;
+        heKeyStates[key.index].inRapidTriggerZone = false;
     // If continuous rapid trigger is enabled, the state is only reset to false when the key is fully released (<0.1mm).
     else if (value >= TRAVEL_DISTANCE_IN_0_01MM - CONTINUOUS_RAPID_TRIGGER_THRESHOLD && key.continuousRapidTrigger)
-        _heKeyStates[key.index].inRapidTriggerZone = false;
+        heKeyStates[key.index].inRapidTriggerZone = false;
 
     // RT STEP 2: If the value entered the rapid trigger zone, perform a press and set the rapid trigger state to true.
     // If the value is below the lower hysteresis and the rapid trigger state is false on the key, press the key because the action of entering
     // the rapid trigger zone is already counted as a trigger. From there on, the actuation point moves dynamically in that zone.
     // Also the rapid trigger state for the key has to be set to true in order to be processed by furture loops.
-    if (value <= key.lowerHysteresis && !_heKeyStates[key.index].inRapidTriggerZone)
+    if (value <= key.lowerHysteresis && !heKeyStates[key.index].inRapidTriggerZone)
     {
         pressKey(key);
-        _heKeyStates[key.index].inRapidTriggerZone = true;
+        heKeyStates[key.index].inRapidTriggerZone = true;
     }
 
     // RT STEP 3: If the key *already is* in the rapid trigger zone (hence the 'else if'), check whether the key has travelled the sufficient amount.
     // Check whether the key should be pressed. This is the case if the key is currently not pressed,
     // the rapid trigger state is true and the value drops more than (down sensitivity) below the highest recorded value.
-    else if (!_heKeyStates[key.index].pressed && _heKeyStates[key.index].inRapidTriggerZone && value + key.rapidTriggerDownSensitivity <= _heKeyStates[key.index].rapidTriggerPeak)
+    else if (!heKeyStates[key.index].pressed && heKeyStates[key.index].inRapidTriggerZone && value + key.rapidTriggerDownSensitivity <= heKeyStates[key.index].rapidTriggerPeak)
         pressKey(key);
     // Check whether the key should be released. This is the case if the key is currently pressed down and either the
     // rapid trigger state is no longer true or the value rises more than (up sensitivity) above the lowest recorded value.
-    else if (_heKeyStates[key.index].pressed && (!_heKeyStates[key.index].inRapidTriggerZone || value >= _heKeyStates[key.index].rapidTriggerPeak + key.rapidTriggerUpSensitivity))
+    else if (heKeyStates[key.index].pressed && (!heKeyStates[key.index].inRapidTriggerZone || value >= heKeyStates[key.index].rapidTriggerPeak + key.rapidTriggerUpSensitivity))
         releaseKey(key);
 
     // RT STEP 4: Always remember the peaks of the values, depending on the current pressed state.
     // If the key is pressed and at an all-time low or not pressed and at an all-time high, save the value.
-    if ((_heKeyStates[key.index].pressed && value < _heKeyStates[key.index].rapidTriggerPeak) || (!_heKeyStates[key.index].pressed && value > _heKeyStates[key.index].rapidTriggerPeak))
-        _heKeyStates[key.index].rapidTriggerPeak = value;
+    if ((heKeyStates[key.index].pressed && value < heKeyStates[key.index].rapidTriggerPeak) || (!heKeyStates[key.index].pressed && value > heKeyStates[key.index].rapidTriggerPeak))
+        heKeyStates[key.index].rapidTriggerPeak = value;
 }
 
 void KeypadHandler::checkDigitalKey(const DigitalKey &key, bool pressed)
 {
     // Check whether the key is pressed and send the HID command.
-    if (pressed && millis() - _digitalKeyStates[key.index].lastDebounce >= DIGITAL_DEBOUNCE_DELAY)
+    if (pressed && millis() - digitalKeyStates[key.index].lastDebounce >= DIGITAL_DEBOUNCE_DELAY)
     {
         pressKey(key);
-        _digitalKeyStates[key.index].lastDebounce = millis();
+        digitalKeyStates[key.index].lastDebounce = millis();
     }
     else if(!pressed)
         releaseKey(key);
@@ -156,8 +157,8 @@ void KeypadHandler::pressKey(const Key &key)
     // Get the pointer to the correct pressed bool depending on the key type.
     // In case the key type is neither digital or hall effect (which shouldn't happen),
     // it defaults to a bool pointer to true, therefore the function exists out further down.
-    bool *pressed = key.type == KeyType::HallEffect ? &_heKeyStates[key.index].pressed
-                  : key.type == KeyType::Digital ? &_digitalKeyStates[key.index].pressed : nullptr;
+    bool *pressed = key.type == KeyType::HallEffect ? &heKeyStates[key.index].pressed
+                  : key.type == KeyType::Digital ? &digitalKeyStates[key.index].pressed : nullptr;
 
     // Check whether the key is already pressed or HID commands are not enabled on the key.
     if (!pressed || *pressed || !key.hidEnabled)
@@ -173,8 +174,8 @@ void KeypadHandler::releaseKey(const Key &key)
     // Get the pointer to the correct pressed bool depending on the key type.
     // In case the key type is neither digital or hall effect (which shouldn't happen),
     // it defaults to a null pointer, therefore the function exists out further down.
-    bool *pressed = key.type == KeyType::HallEffect ? &_heKeyStates[key.index].pressed
-                  : key.type == KeyType::Digital ? &_digitalKeyStates[key.index].pressed : nullptr;
+    bool *pressed = key.type == KeyType::HallEffect ? &heKeyStates[key.index].pressed
+                  : key.type == KeyType::Digital ? &digitalKeyStates[key.index].pressed : nullptr;
 
     // Check whether the key is already pressed or HID commands are not enabled on the key.
     if (!pressed || !*pressed)
@@ -207,8 +208,7 @@ uint16_t KeypadHandler::readKey(const Key &key)
 #endif
 
         // Filter the value through the SMA filter and return it.
-        _heKeyStates[key.index].lastSensorValue = _heKeyStates[key.index].filter(value);
-        return _heKeyStates[key.index].lastSensorValue;
+        return heKeyStates[key.index].filter(value);
     }
     // Otherwise, in case anything goes wrong, default to 0.
     else

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -219,7 +219,6 @@ void SerialHandler::name(char *name)
 
 void SerialHandler::out(bool single, bool state)
 {
-    print("single: %d state: %d", single ? 1 : 0, state ? 1 : 0);
     // If single is true, no argument was specified. In that case just output every key once.
     if (single)
         for (const HEKey &key : ConfigController.config.heKeys)

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -41,7 +41,7 @@ void SerialHandler::handleSerialInput(String *inputStr)
     else if (isEqual(command, "name"))
         name(parameters);
     else if (isEqual(command, "out"))
-        out(isTrue(arg0));
+        out(isEqual(arg0, ""), isTrue(arg0));
 #ifdef DEV
     else if (isEqual(command, "echo"))
         echo(parameters);
@@ -147,7 +147,7 @@ void SerialHandler::handleSerialInput(String *inputStr)
 void SerialHandler::printHEKeyOutput(const HEKey &key)
 {
     // Print out the index of the key, the last sensor reading and the last mapped value in the output format.
-    print("OUT hkey%d=%d %d", key.index, KeypadHandler.heKeyStates[key.index].lastSensorValue, KeypadHandler.heKeyStates[key.index].lastMappedValue);
+    print("OUT hkey%d=%d %d", key.index + 1, KeypadHandler.heKeyStates[key.index].lastSensorValue, KeypadHandler.heKeyStates[key.index].lastMappedValue);
 }
 
 void SerialHandler::boot()
@@ -209,10 +209,15 @@ void SerialHandler::name(char *name)
         memcpy(ConfigController.config.name, name + '\0', length + 1);
 }
 
-void SerialHandler::out(bool state)
+void SerialHandler::out(bool single, bool state)
 {
-    // Set the calibration mode field of the keypad handler to the specified state.
-    KeypadHandler.outputMode = state;
+    // If single is true, no argument was specified. In that case just output every key once.
+    if (single)
+        for (const HEKey &key : ConfigController.config.heKeys)
+            printHEKeyOutput(key);
+    else
+        // Otherwise, set the calibration mode field of the keypad handler to the specified state.
+        KeypadHandler.outputMode = state;
 }
 
 void SerialHandler::echo(char *input)

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -26,8 +26,16 @@ void SerialHandler::handleSerialInput(String *inputStr)
     char command[1024];
     StringHelper::getArgumentAt(input, ' ', 0, command);
 
-    // Get a pointer pointing to the start of all parameters for the command and parse them.
-    char *parameters = input + strlen(command) + 1;
+    // Get a pointer pointing to the start of all parameters for the command.
+    char *parameters = input + strlen(command);
+
+    // If the parameters start with a " " it means parameters have been specified.
+    // It's needed because if there are no parameters there's a zero-terminator instead.
+    // Skipping that zero-terminator would lead to arguments filled with memory garbage.
+    if (strstr(parameters, " ") == parameters)
+        parameters += 1;
+
+    // Parse all arguments.
     char arg0[1024];
     StringHelper::getArgumentAt(parameters, ' ', 0, arg0);
 
@@ -211,6 +219,7 @@ void SerialHandler::name(char *name)
 
 void SerialHandler::out(bool single, bool state)
 {
+    print("single: %d state: %d", single ? 1 : 0, state ? 1 : 0);
     // If single is true, no argument was specified. In that case just output every key once.
     if (single)
         for (const HEKey &key : ConfigController.config.heKeys)

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -144,6 +144,12 @@ void SerialHandler::handleSerialInput(String *inputStr)
     }
 }
 
+void SerialHandler::printHEKeyOutput(const HEKey &key)
+{
+    // Print out the index of the key, the last sensor reading and the last mapped value in the output format.
+    print("OUT hkey%d=%d %d", key.index, KeypadHandler.heKeyStates[key.index].lastSensorValue, KeypadHandler.heKeyStates[key.index].lastMappedValue);
+}
+
 void SerialHandler::boot()
 {
     // Set the RP2040 into bootloader mode.


### PR DESCRIPTION
This PR adds a new functionality to the `out` command. If you just send it, without any parameter which would enable/disable the output mode, it will print out the raw and mapped sensor values just once, in the same format as with output mode.