### PR TITLE
qol: switch to built-in `serialEvent` function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@ void setup()
 
 void loop()
 {
-    // Check for any serial commands received.
-    while (Serial.available())
-    {
-        String str = Serial.readStringUntil('\n');
-        SerialHandler.handleSerialInput(&str);
-    }
-
     // Run the keypad handler checks to handle the actual keypad functionality.
     KeypadHandler.handle();
+}
+
+void serialEvent()
+{
+    // Handle incoming serial data.
+    String str = Serial.readStringUntil('\n');
+    SerialHandler.handleSerialInput(&str);
 }


### PR DESCRIPTION
The Arduino Core provides a function, `serialEvent`, for handling serial data if it's available.
Therefore, instead of having a `while (Serial.available() > 0)` we can just use that event.