### PR TITLE
qol: Avoid usage of String by switching to consistent, fixed-length input buffers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,8 @@
         "ranges": "cpp",
         "iosfwd": "cpp",
         "limits": "cpp",
-        "streambuf": "cpp"
+        "streambuf": "cpp",
+        "string_view": "cpp"
     },
     "cmake.configureOnOpen": false
 }

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -29,6 +29,9 @@
 // The resolution for the ADCs on the RP2040. The maximum compatible value on it is 16 bit.
 #define ANALOG_RESOLUTION 12
 
+// The buffer size of any serial input. Defined here for consistent use across the serial handler and avoiding of magic numbers.
+#define SERIAL_INPUT_BUFFER_SIZE 1024
+
 // The exponent for the amount of samples for the SMA filter. This filter reduces fluctuation of analog values.
 // A value too high may cause unresponsiveness. 1 = 1 sample, 2 = 4 samples, 3 = 8 samples, 4 = 16 samples, ...
 #define SMA_FILTER_SAMPLE_EXPONENT 4

--- a/include/handlers/serial_handler.hpp
+++ b/include/handlers/serial_handler.hpp
@@ -5,7 +5,7 @@
 inline class SerialHandler
 {
 public:
-    void handleSerialInput(String *inputStr);
+    void handleSerialInput(char *input);
     void printHEKeyOutput(const HEKey &key);
 
 private:

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -15,15 +15,13 @@ extern "C"
 #define isEqual(str1, str2) strcmp(str1, str2) == 0
 #define isTrue(str) isEqual(str, "1") || isEqual(str, "true")
 
-void SerialHandler::handleSerialInput(String *inputStr)
+void SerialHandler::handleSerialInput(char *input)
 {
-    // Convert the string into a character array for further parsing and make it lowercase.
-    char input[(*inputStr).length() + 1];
-    (*inputStr).toCharArray(input, (*inputStr).length() + 1);
+    // Make the input buffer lowercase for further parsing.
     StringHelper::toLower(input);
 
     // Parse the command as the first argument, separated by whitespaces.
-    char command[1024];
+    char command[SERIAL_INPUT_BUFFER_SIZE];
     StringHelper::getArgumentAt(input, ' ', 0, command);
 
     // Get a pointer pointing to the start of all parameters for the command.
@@ -36,7 +34,7 @@ void SerialHandler::handleSerialInput(String *inputStr)
         parameters += 1;
 
     // Parse all arguments.
-    char arg0[1024];
+    char arg0[SERIAL_INPUT_BUFFER_SIZE];
     StringHelper::getArgumentAt(parameters, ' ', 0, arg0);
 
     // Handle the global commands and pass their expected required parameters.
@@ -59,8 +57,8 @@ void SerialHandler::handleSerialInput(String *inputStr)
     if (strstr(command, "hkey") == command)
     {
         // Split the command into the key string and the setting name.
-        char keyStr[1024];
-        char setting[1024];
+        char keyStr[SERIAL_INPUT_BUFFER_SIZE];
+        char setting[SERIAL_INPUT_BUFFER_SIZE];
         StringHelper::getArgumentAt(command, '.', 0, keyStr);
         StringHelper::getArgumentAt(command, '.', 1, setting);
 
@@ -114,8 +112,8 @@ void SerialHandler::handleSerialInput(String *inputStr)
     if (strstr(command, "dkey") == command)
     {
         // Split the command into the key string and the setting name.
-        char keyStr[1024];
-        char setting[1024];
+        char keyStr[SERIAL_INPUT_BUFFER_SIZE];
+        char setting[SERIAL_INPUT_BUFFER_SIZE];
         StringHelper::getArgumentAt(command, '.', 0, keyStr);
         StringHelper::getArgumentAt(command, '.', 1, setting);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "config/configuration_controller.hpp"
 #include "handlers/serial_handler.hpp"
 #include "handlers/keypad_handler.hpp"
+#include "definitions.hpp"
 
 void setup()
 {
@@ -32,6 +33,14 @@ void loop()
 void serialEvent()
 {
     // Handle incoming serial data.
-    String str = Serial.readStringUntil('\n');
-    SerialHandler.handleSerialInput(&str);
+    while(Serial.available() > 0)
+    {
+        // Read the incoming serial data until a newline into a buffer and terminate it with a null terminator.
+        char input[SERIAL_INPUT_BUFFER_SIZE];
+        const size_t inputLength = Serial.readBytesUntil('\n', input, SERIAL_INPUT_BUFFER_SIZE);
+        input[inputLength] = '\0';
+
+        // Pass the read input to the serial handler to handle it.
+        SerialHandler.handleSerialInput(input);
+    }
 }


### PR DESCRIPTION
Replaces the `readStringUntil` call with `readBytesUntil` and avoids using Arduino's `String` class by working with character arrays. Also introduces a new definition, `SERIAL_INPUT_BUFFER_SIZE` which is used instead of `1024` to avoid magic numbers for buffer sizes.