### PR TITLE
qol: Replace stdint.h with cstdint

### DIFF
--- a/include/config/keys/digital_key.hpp
+++ b/include/config/keys/digital_key.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include "config/keys/key.hpp"
 
 // Configuration for the digital keys of the keypad.

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include "config/keys/key.hpp"
 #include "config/keys/key_type.hpp"
 

--- a/include/config/keys/key.hpp
+++ b/include/config/keys/key.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include "config/keys/key_type.hpp"
 
 // The base configuration struct for the DigitalKey and HEKey struct, containing the common fields.

--- a/include/helpers/sma_filter.hpp
+++ b/include/helpers/sma_filter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 class SMAFilter
 {

--- a/include/helpers/string_helper.hpp
+++ b/include/helpers/string_helper.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace StringHelper
 {


### PR DESCRIPTION
Despite [this comment](https://github.com/minipadKB/minipad-firmware/pull/19#issuecomment-1675853887) I decided to do this anyways after some discussion. It's essentially the same, but considered better practice, despite `Arduino.h` importing `stdint.h`.