### PR TITLE
feat: allow all characters to be used

### DIFF
--- a/include/config/configuration.hpp
+++ b/include/config/configuration.hpp
@@ -22,7 +22,7 @@ struct Configuration
     static uint32_t getVersion()
     {
         // Version of the configuration in the format YYMMDDhhmm (e.g. 2301030040 for 12:44am on the 3rd january 2023)
-        int64_t version = 2304281204;
+        int64_t version = 2305261535;
 
         return version;
     }

--- a/include/config/configuration_controller.hpp
+++ b/include/config/configuration_controller.hpp
@@ -49,10 +49,6 @@ private:
             config.heKeys[i].rapidTriggerDownSensitivity = TRAVEL_DISTANCE_IN_0_01MM / 10;
             config.heKeys[i].lowerHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.55);
             config.heKeys[i].upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
-
-            // Set the calibration values to the outer boundaries of the possible values to "disable" them.
-            config.heKeys[i].restPosition = pow(2, ANALOG_RESOLUTION) - 1;
-            config.heKeys[i].downPosition = 0;
         }
 
         // Populate the digital keys array with the correct amount of digital keys.

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -27,8 +27,4 @@ struct HEKey : Key
 
     // The value below which the key is no longer pressed and rapid trigger is no longer active in rapid trigger mode.
     uint16_t upperHysteresis;
-
-    // The value read when the keys are in rest position/all the way down.
-    uint16_t restPosition;
-    uint16_t downPosition;
 };

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -32,7 +32,7 @@
 // 7 may seem like much at first but when "smashing" the button a lot it'll be just right.
 #define AUTO_CALIBRATION_DEADZONE 7
 
-// The resolution for the ADCs on the RP2040. The maximum compatible value on it is 16 bit.
+// The resolution for the ADCs on the RP2040. The theoretical maximum value on it is 16 bit (uint16_t).
 #define ANALOG_RESOLUTION 12
 
 // The exponent for the amount of samples for the SMA filter. This filter reduces fluctuation of analog values.

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -26,6 +26,12 @@
 // This value is important to reset the rapid trigger state properly with continuous rapid trigger.
 #define CONTINUOUS_RAPID_TRIGGER_THRESHOLD 10
 
+// This number will be added to the down position and substracted from the rest position on calibration
+// to introduce a deadzone at the boundaries. This might be desired since values might fluctuate.
+// e.g. if the value fluctuates around 1970 in rest position but peaks at 1975, this would counteract it.
+// 7 may seem like much at first but when "smashing" the button a lot it'll be just right.
+#define AUTO_CALIBRATION_DEADZONE 7
+
 // The resolution for the ADCs on the RP2040. The maximum compatible value on it is 16 bit.
 #define ANALOG_RESOLUTION 12
 

--- a/include/handlers/key_states/he_key_state.hpp
+++ b/include/handlers/key_states/he_key_state.hpp
@@ -23,6 +23,12 @@ struct HEKeyState : KeyState
     // The mapped version of the value read from the hall effect sensor.
     uint16_t lastMappedValue = 0;
 
+    // The highest and lowest values ever read on the sensor. Used for calibration purposes,
+    // specifically mapping future values read from the sensors from this range to 0.01mm steps.
+    // By default, set the range from analog_resolution²-1 to 0 so it can be updated.
+    uint16_t restPosition = 0;
+    uint16_t downPosition = 4095;
+
     // The simple moving average filter for stabilizing the analog outpt.
     SMAFilter filter = SMAFilter(SMA_FILTER_SAMPLE_EXPONENT);
 };

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -28,7 +28,7 @@ public:
     DigitalKeyState digitalKeyStates[DIGITAL_KEYS];
 
 private:
-
+    void updateCalibrationValues(const HEKey &key, uint16_t value);
     void checkHEKey(const HEKey &key, uint16_t value);
     void checkDigitalKey(const DigitalKey &key, bool pressed);
     void pressKey(const Key &key);

--- a/include/handlers/serial_handler.hpp
+++ b/include/handlers/serial_handler.hpp
@@ -21,8 +21,6 @@ private:
     void hkey_rtds(HEKey &key, uint16_t value);
     void hkey_lh(HEKey &key, uint16_t value);
     void hkey_uh(HEKey &key, uint16_t value);
-    void hkey_rest(HEKey &key, uint16_t value);
-    void hkey_down(HEKey &key, uint16_t value);
     void key_char(Key &key, uint8_t keyChar);
     void key_hid(Key &key, bool state);
 } SerialHandler;

--- a/include/helpers/sma_filter.hpp
+++ b/include/helpers/sma_filter.hpp
@@ -11,16 +11,27 @@ public:
     // (1 = 1 sample, 2 = 4 samples, 3 = 8 samples, ...)
     SMAFilter(uint8_t samplesExponent)
         : samplesExponent(samplesExponent)
-        , samples(pow(2, samplesExponent))
+        , samples(1 << samplesExponent)
         , buffer(new uint16_t[samples] {0})
     {}
 
+    // The call operator for passing values through the filter.
     uint16_t operator()(uint16_t value);
 
+    // Bool whether the whole buffer has been written at least once.
+    bool initialized = false;
+
 private:
+    // The amount of samples and the exponent.
     uint8_t samplesExponent;
     uint8_t samples;
+
+    // The buffer containing all values.
     uint16_t *buffer;
+
+    // The index of the oldest and thus next element to overwrite.
     uint8_t index = 0;
+
+    // The sum of all values in the buffer.
     uint32_t sum = 0;
 };

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -78,6 +78,7 @@ void KeypadHandler::handle()
         if (!heKeyStates[key.index].filter.initialized)
             continue;
 
+        // Make sure to run checks on the calibration values, updating them if available.
         updateCalibrationValues(key, value);
 
         // Run the checks on the HE key.

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -106,7 +106,8 @@ void KeypadHandler::updateCalibrationValues(const HEKey &key, uint16_t value)
         heKeyStates[key.index].restPosition = value - AUTO_CALIBRATION_DEADZONE;
     // If the read value is lower than the current down position (with deadzone applied), update it. Make sure that the distance to the rest position
     // is at least 200 (scaled with the travel distance at a base of 4.00mm) to prevent inaccurate calibration resulting in "crazy behaviour"
-    else if (heKeyStates[key.index].downPosition > value + 5 && heKeyStates[key.index].restPosition - value + 5 >= 200 * TRAVEL_DISTANCE_IN_0_01MM / 400)
+    else if (heKeyStates[key.index].downPosition > value + AUTO_CALIBRATION_DEADZONE &&
+             heKeyStates[key.index].restPosition - value + AUTO_CALIBRATION_DEADZONE >= 200 * TRAVEL_DISTANCE_IN_0_01MM / 400)
         heKeyStates[key.index].downPosition = value + AUTO_CALIBRATION_DEADZONE;
 }
 

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -100,13 +100,13 @@ void KeypadHandler::handle()
 
 void KeypadHandler::updateCalibrationValues(const HEKey &key, uint16_t value)
 {
-    // If the read value is bigger than the current rest position calibration, update it.
-    if (heKeyStates[key.index].restPosition < value)
-        heKeyStates[key.index].restPosition = value;
-    // If the read value is lower than the current down position, update it. Make sure that the distance to the rest position
+    // If the read value is bigger than the current rest position calibration (with deadzone applied), update it.
+    if (heKeyStates[key.index].restPosition < value - AUTO_CALIBRATION_DEADZONE)
+        heKeyStates[key.index].restPosition = value - AUTO_CALIBRATION_DEADZONE;
+    // If the read value is lower than the current down position (with deadzone applied), update it. Make sure that the distance to the rest position
     // is at least 200 (scaled with the travel distance at a base of 4.00mm) to prevent inaccurate calibration resulting in "crazy behaviour"
-    else if (heKeyStates[key.index].downPosition > value && heKeyStates[key.index].restPosition - value >= 200 * TRAVEL_DISTANCE_IN_0_01MM / 400)
-        heKeyStates[key.index].downPosition = value;
+    else if (heKeyStates[key.index].downPosition > value + 5 && heKeyStates[key.index].restPosition - value + 5 >= 200 * TRAVEL_DISTANCE_IN_0_01MM / 400)
+        heKeyStates[key.index].downPosition = value + AUTO_CALIBRATION_DEADZONE;
 }
 
 void KeypadHandler::checkHEKey(const HEKey &key, uint16_t value)

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -278,10 +278,8 @@ void SerialHandler::hkey_uh(HEKey &key, uint16_t value)
 
 void SerialHandler::key_char(Key &key, uint8_t keyChar)
 {
-    // Check if the specified key is a letter with a byte value between 97 (a) and 122 (z).
-    if (keyChar >= 'a' && keyChar <= 'z')
-        // Set the key config value of the specified key to the specified state.
-        key.keyChar = keyChar;
+    // Set the key config value of the specified key to the specified state.
+    key.keyChar = keyChar;
 }
 
 void SerialHandler::key_hid(Key &key, bool state)

--- a/src/handlers/serial_handler.cpp
+++ b/src/handlers/serial_handler.cpp
@@ -99,10 +99,6 @@ void SerialHandler::handleSerialInput(String *inputStr)
                 hkey_lh(key, atoi(arg0));
             else if (isEqual(setting, "uh"))
                 hkey_uh(key, atoi(arg0));
-            else if (isEqual(setting, "rest"))
-                hkey_rest(key, atoi(arg0));
-            else if (isEqual(setting, "down"))
-                hkey_down(key, atoi(arg0));
             else if (isEqual(setting, "char"))
                 key_char(key, atoi(arg0));
             else if (isEqual(setting, "hid"))
@@ -193,8 +189,8 @@ void SerialHandler::get()
         print("GET hkey%d.lh=%d", key.index + 1, key.lowerHysteresis);
         print("GET hkey%d.uh=%d", key.index + 1, key.upperHysteresis);
         print("GET hkey%d.char=%d", key.index + 1, key.keyChar);
-        print("GET hkey%d.rest=%d", key.index + 1, key.restPosition);
-        print("GET hkey%d.down=%d", key.index + 1, key.downPosition);
+        print("GET hkey%d.rest=%d", key.index + 1, KeypadHandler.heKeyStates[key.index].restPosition);
+        print("GET hkey%d.down=%d", key.index + 1, KeypadHandler.heKeyStates[key.index].downPosition);
         print("GET hkey%d.hid=%d", key.index + 1, key.hidEnabled);
     }
 
@@ -278,22 +274,6 @@ void SerialHandler::hkey_uh(HEKey &key, uint16_t value)
     if (value - key.lowerHysteresis >= HYSTERESIS_TOLERANCE && TRAVEL_DISTANCE_IN_0_01MM - value >= HYSTERESIS_TOLERANCE)
         // Set the upper hysteresis config value to the specified state.
         key.upperHysteresis = value;
-}
-
-void SerialHandler::hkey_rest(HEKey &key, uint16_t value)
-{
-    // Check whether the specified value is bigger than the down position and smaller or equal to the maximum analog value.
-    if (value > key.downPosition && value <= pow(2, ANALOG_RESOLUTION) - 1)
-        // Set the rest position config value of the specified key to the specified state.
-        key.restPosition = value;
-}
-
-void SerialHandler::hkey_down(HEKey &key, uint16_t value)
-{
-    // Check whether the specified value is smaller than the rest position.
-    if (value < key.restPosition)
-        // Set the down position config value of the specified key to the specified state.
-        key.downPosition = value;
 }
 
 void SerialHandler::key_char(Key &key, uint8_t keyChar)

--- a/src/helpers/sma_filter.cpp
+++ b/src/helpers/sma_filter.cpp
@@ -13,6 +13,10 @@ uint16_t SMAFilter::operator()(uint16_t value)
     // Move the index by 1 or restart at 0 if the end is reached.
     index = (index + 1) % samples;
 
+    // If the index is 0 here (meaning the circular index just reset), set the fully initialized state to true.
+    if(index == 0)
+        initialized = true;
+
     // Divide the number by the amount of samples using bitshifting and return it.
     return sum >> samplesExponent;
 }


### PR DESCRIPTION
Removes the if-statement on the `hkey.char` command in order to allow keys like space or escape to be used.