### PR TITLE
qol: migrate default configuration values to their structs

### DIFF
--- a/include/config/configuration.hpp
+++ b/include/config/configuration.hpp
@@ -22,7 +22,7 @@ struct Configuration
     static uint32_t getVersion()
     {
         // Version of the configuration in the format YYMMDDhhmm (e.g. 2301030040 for 12:44am on the 3rd january 2023)
-        int64_t version = 2304281204;
+        int64_t version = 2308130046;
 
         return version;
     }

--- a/include/config/configuration.hpp
+++ b/include/config/configuration.hpp
@@ -10,13 +10,13 @@ struct Configuration
     uint32_t version = Configuration::getVersion();
 
     // The name of the keypad, used to distinguish it from others.
-    char name[128];
+    char name[128] = "minipad";
 
     // A list of all hall effect key configurations. (rapid trigger, hysteresis, calibration, ...)
-    HEKey heKeys[HE_KEYS];
+    HEKey heKeys[HE_KEYS] = {};
 
     // A list of all digital key configurations. (key char, hid state, ...)
-    DigitalKey digitalKeys[DIGITAL_KEYS];
+    DigitalKey digitalKeys[DIGITAL_KEYS] = {};
 
     // Returns the version constant of the latest Configuration layout.
     static uint32_t getVersion()

--- a/include/config/configuration.hpp
+++ b/include/config/configuration.hpp
@@ -13,10 +13,10 @@ struct Configuration
     char name[128] = "minipad";
 
     // A list of all hall effect key configurations. (rapid trigger, hysteresis, calibration, ...)
-    HEKey heKeys[HE_KEYS] = {};
+    HEKey heKeys[HE_KEYS];
 
     // A list of all digital key configurations. (key char, hid state, ...)
-    DigitalKey digitalKeys[DIGITAL_KEYS] = {};
+    DigitalKey digitalKeys[DIGITAL_KEYS];
 
     // Returns the version constant of the latest Configuration layout.
     static uint32_t getVersion()

--- a/include/config/configuration_controller.hpp
+++ b/include/config/configuration_controller.hpp
@@ -25,7 +25,7 @@ private:
     // structs that might get modified on a firmware update and have to be reset back to their default values then later on.
     Configuration getDefaultConfig()
     {
-        Configuration config = Configuration();
+        Configuration config;
 
         // Populate the hall effect keys array with the correct amount of hall effect keys.
         for (uint8_t i = 0; i < HE_KEYS; i++)

--- a/include/config/configuration_controller.hpp
+++ b/include/config/configuration_controller.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#pragma GCC diagnostic ignored "-Wtype-limits"
 
 #include "config/configuration.hpp"
 #include "definitions.hpp"
@@ -24,50 +25,15 @@ private:
     // structs that might get modified on a firmware update and have to be reset back to their default values then later on.
     Configuration getDefaultConfig()
     {
-        Configuration config = {
-            .name = {'m', 'i', 'n', 'i', 'p', 'a', 'd'},
-            .heKeys = {},
-            .digitalKeys = {}
-        };
+        Configuration config = Configuration();
 
         // Populate the hall effect keys array with the correct amount of hall effect keys.
         for (uint8_t i = 0; i < HE_KEYS; i++)
-        {
-            config.heKeys[i] = HEKey();
-            config.heKeys[i].index = i;
-
-            // Assign the keys from z downwards. (z, y, x, w, v, ...)
-            // After 26 keys, stick to an 'a' key to not overflow.
-            config.heKeys[i].keyChar = i >= 26 ? 'a' : (char)('z' - i);
-
-            config.heKeys[i].hidEnabled = false;
-            config.heKeys[i].rapidTrigger = false;
-            config.heKeys[i].continuousRapidTrigger = false;
-
-            // For the default values of these values, a value depending on the total travel distance is being used.
-            config.heKeys[i].rapidTriggerUpSensitivity = TRAVEL_DISTANCE_IN_0_01MM / 10;
-            config.heKeys[i].rapidTriggerDownSensitivity = TRAVEL_DISTANCE_IN_0_01MM / 10;
-            config.heKeys[i].lowerHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.55);
-            config.heKeys[i].upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
-
-            // Set the calibration values to the outer boundaries of the possible values to "disable" them.
-            config.heKeys[i].restPosition = pow(2, ANALOG_RESOLUTION) - 1;
-            config.heKeys[i].downPosition = 0;
-        }
+            config.heKeys[i] = HEKey(i);
 
         // Populate the digital keys array with the correct amount of digital keys.
-#pragma GCC diagnostic ignored "-Wtype-limits"
         for (uint8_t i = 0; i < DIGITAL_KEYS; i++)
-#pragma GCC diagnostic pop
-        {
-            config.digitalKeys[i] = DigitalKey();
-            config.digitalKeys[i].index = i;
-
-            // Assign the keys from a forwards. (a, b, c, d, e, ...)
-            // After 26 keys, stick to an 'z' key to not overflow.
-            config.digitalKeys[i].keyChar = i >= 26 ? 'z' : (char)('a' + i),
-            config.digitalKeys[i].hidEnabled = false;
-        }
+            config.digitalKeys[i] = DigitalKey(i);
 
         return config;
     };

--- a/include/config/keys/digital_key.hpp
+++ b/include/config/keys/digital_key.hpp
@@ -6,8 +6,9 @@
 // Configuration for the digital keys of the keypad.
 struct DigitalKey : Key
 {
-    // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. DigitalKey).
-    DigitalKey() { type = KeyType::Digital; }
+    // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. DigitalKey) and index.
+    // Assign the key char from a forwards (a, b, c, d, e, ...). After 26 keys, stick to an 'z' key to not overflow.
+    DigitalKey(uint8_t index) : Key(KeyType::Digital, index, index >= 26 ? 'z' : (char)('a' + index)) {}
 
     // This struct is empty on purpose. The only purpose it serves is explicitly having
     // a type for the digital keys, instead of differentiating between Key and DigitalKey.

--- a/include/config/keys/digital_key.hpp
+++ b/include/config/keys/digital_key.hpp
@@ -6,6 +6,7 @@
 // Configuration for the digital keys of the keypad.
 struct DigitalKey : Key
 {
+    // Default constructor for the DigitalKey struct for initializing the arrays in the Configuration struct.
     DigitalKey() : Key(KeyType::Digital, 0, '\0') {}
 
     // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. DigitalKey) and index.

--- a/include/config/keys/digital_key.hpp
+++ b/include/config/keys/digital_key.hpp
@@ -7,6 +7,7 @@
 struct DigitalKey : Key
 {
     DigitalKey() : Key(KeyType::Digital, 0, '\0') {}
+
     // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. DigitalKey) and index.
     // Assign the key char from a forwards (a, b, c, d, e, ...). After 26 keys, stick to an 'z' key to not overflow.
     DigitalKey(uint8_t index) : Key(KeyType::Digital, index, index >= 26 ? 'z' : (char)('a' + index)) {}

--- a/include/config/keys/digital_key.hpp
+++ b/include/config/keys/digital_key.hpp
@@ -6,6 +6,7 @@
 // Configuration for the digital keys of the keypad.
 struct DigitalKey : Key
 {
+    DigitalKey() : Key(KeyType::Digital, 0, '\0') {}
     // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. DigitalKey) and index.
     // Assign the key char from a forwards (a, b, c, d, e, ...). After 26 keys, stick to an 'z' key to not overflow.
     DigitalKey(uint8_t index) : Key(KeyType::Digital, index, index >= 26 ? 'z' : (char)('a' + index)) {}

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -33,6 +33,6 @@ struct HEKey : Key
     uint16_t upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
 
     // The value read when the keys are in rest position/all the way down.
-    uint16_t restPosition = pow(2, ANALOG_RESOLUTION) - 1; // Set to the outer boundaries in order to make
-    uint16_t downPosition = 0;                             // them overwritable by the calibration code.
+    uint16_t restPosition = 0;                             // Set to the outer boundaries in order to make
+    uint16_t downPosition = pow(2, ANALOG_RESOLUTION) - 1; // them overwritable by the calibration code.
 };

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -8,6 +8,8 @@
 // Configuration for the hall effect keys of the keypad, containing the actuation points, calibration, sensitivities etc. of the key.
 struct HEKey : Key
 {
+    HEKey() : Key(KeyType::HallEffect, 0, '\0') {}
+
     // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. HEKey) and index.
     // Assign the key char from z downwards (z, y, x, w, v, ...). After 26 keys, stick to an 'a' key to not overflow.
     HEKey(uint8_t index) : Key(KeyType::HallEffect, index, index >= 26 ? 'a' : (char)('z' - index)) {}

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -3,32 +3,34 @@
 #include <cstdint>
 #include "config/keys/key.hpp"
 #include "config/keys/key_type.hpp"
+#include "definitions.hpp"
 
 // Configuration for the hall effect keys of the keypad, containing the actuation points, calibration, sensitivities etc. of the key.
 struct HEKey : Key
 {
-    // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. HEKey).
-    HEKey() { type = KeyType::HallEffect; }
+    // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. HEKey) and index.
+    // Assign the key char from z downwards (z, y, x, w, v, ...). After 26 keys, stick to an 'a' key to not overflow.
+    HEKey(uint8_t index) : Key(KeyType::HallEffect, index, index >= 26 ? 'a' : (char)('z' - index)) {}
 
     // Bool whether rapid trigger is enabled or not.
-    bool rapidTrigger;
+    bool rapidTrigger = false;
 
     // Bool whether continuous rapid trigger is enabled or not.
-    bool continuousRapidTrigger;
+    bool continuousRapidTrigger = false;
 
     // The sensitivity of the rapid trigger algorithm when pressing up.
-    uint16_t rapidTriggerUpSensitivity;
+    uint16_t rapidTriggerUpSensitivity = TRAVEL_DISTANCE_IN_0_01MM / 10;
 
     // The sensitivity of the rapid trigger algorithm when pressing down.
-    uint16_t rapidTriggerDownSensitivity;
+    uint16_t rapidTriggerDownSensitivity = TRAVEL_DISTANCE_IN_0_01MM / 10;
 
     // The value below which the key is pressed and rapid trigger is active in rapid trigger mode.
-    uint16_t lowerHysteresis;
+    uint16_t lowerHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.55);
 
     // The value below which the key is no longer pressed and rapid trigger is no longer active in rapid trigger mode.
-    uint16_t upperHysteresis;
+    uint16_t upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
 
     // The value read when the keys are in rest position/all the way down.
-    uint16_t restPosition;
-    uint16_t downPosition;
+    uint16_t restPosition = pow(2, ANALOG_RESOLUTION) - 1; // Set to the outer boundaries in order to make
+    uint16_t downPosition = 0;                             // them overwritable by the calibration code.
 };

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -33,6 +33,6 @@ struct HEKey : Key
     uint16_t upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
 
     // The value read when the keys are in rest position/all the way down.
-    uint16_t restPosition = 0;                             // Set to the outer boundaries in order to make
-    uint16_t downPosition = pow(2, ANALOG_RESOLUTION) - 1; // them overwritable by the calibration code.
+    uint16_t restPosition = pow(2, ANALOG_RESOLUTION) - 1; // Set to the outer boundaries in order to make
+    uint16_t downPosition = 0;                             // them overwritable by the calibration code.
 };

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -8,6 +8,7 @@
 // Configuration for the hall effect keys of the keypad, containing the actuation points, calibration, sensitivities etc. of the key.
 struct HEKey : Key
 {
+    // Default constructor for the HEKey struct for initializing the arrays in the Configuration struct.
     HEKey() : Key(KeyType::HallEffect, 0, '\0') {}
 
     // Initialize with the correct type for identifying the type of key that a Key object was initialized as (e.g. HEKey) and index.

--- a/include/config/keys/key.hpp
+++ b/include/config/keys/key.hpp
@@ -6,8 +6,16 @@
 // The base configuration struct for the DigitalKey and HEKey struct, containing the common fields.
 struct Key
 {
+    // Require every key to be initialized with a type, index and key char.
+    Key(KeyType t, uint8_t i, char c)
+    {
+        type = t;
+        index = i;
+        keyChar = c;
+    }
+
     // Used to identify the type of key that a Key object was initialized as (e.g. HEKey or DigitalKey).
-    KeyType type = KeyType::Base;
+    KeyType type;
 
     // The index of the key. This is hardcoded in the default config and is not changed.
     // It does not serve a config purpose but is instead for accessing the index from the DigitalKey object.
@@ -17,5 +25,5 @@ struct Key
     char keyChar;
 
     // Bools whether HID commands are sent on the key.
-    bool hidEnabled;
+    bool hidEnabled = false;
 };

--- a/include/config/keys/key_type.hpp
+++ b/include/config/keys/key_type.hpp
@@ -3,9 +3,6 @@
 // An enum used to identify the type of key a Key object represents.
 enum KeyType
 {
-    // Key objects of this type have been initialized as neither an HEKey or DigitalKey object.
-    Base,
-
     // A Key object that was initialized as an HEKey object.
     HallEffect,
 

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -53,8 +53,6 @@
 // meaning on a 3-key device the pins are 28, 27 and 26. This macro has to be adjusted, depending on how the PCB
 // and hardware of the device using this firmware has been designed. The A0 constant is 26 in the RP2040 environment.
 // NOTE: By the uint8 datatype, the amount of keys is limited to 255.
-// NOTE: By the default config initialization, the amount of keys is limited to
-//       around 26 since the characters are assigned backwards started from 'z'.
 // NOTE: By the RP2040, the amount of analog pins (and therefore keys) is limited o 4.
 #define HE_PIN(index) A0 + HE_KEYS - index - 1
 
@@ -70,7 +68,7 @@
 #endif
 
 // Add a compiler error if the firmware is being tried to built with more than the supported 26 digital keys.
-// (limited amount of ports + characters)
+// (limited amount of ports)
 #if DIGITAL_KEYS > 26
 #error As of right now, the firmware only supports up to 26 digital keys.
 #endif

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -148,7 +148,7 @@ void KeypadHandler::checkDigitalKey(const DigitalKey &key, bool pressed)
         pressKey(key);
         digitalKeyStates[key.index].lastDebounce = millis();
     }
-    else if(!pressed)
+    else if (!pressed)
         releaseKey(key);
 }
 
@@ -158,7 +158,8 @@ void KeypadHandler::pressKey(const Key &key)
     // In case the key type is neither digital or hall effect (which shouldn't happen),
     // it defaults to a bool pointer to true, therefore the function exists out further down.
     bool *pressed = key.type == KeyType::HallEffect ? &heKeyStates[key.index].pressed
-                  : key.type == KeyType::Digital ? &digitalKeyStates[key.index].pressed : nullptr;
+                    : key.type == KeyType::Digital  ? &digitalKeyStates[key.index].pressed
+                                                    : nullptr;
 
     // Check whether the key is already pressed or HID commands are not enabled on the key.
     if (!pressed || *pressed || !key.hidEnabled)
@@ -175,7 +176,8 @@ void KeypadHandler::releaseKey(const Key &key)
     // In case the key type is neither digital or hall effect (which shouldn't happen),
     // it defaults to a null pointer, therefore the function exists out further down.
     bool *pressed = key.type == KeyType::HallEffect ? &heKeyStates[key.index].pressed
-                  : key.type == KeyType::Digital ? &digitalKeyStates[key.index].pressed : nullptr;
+                    : key.type == KeyType::Digital  ? &digitalKeyStates[key.index].pressed
+                                                    : nullptr;
 
     // Check whether the key is already pressed or HID commands are not enabled on the key.
     if (!pressed || !*pressed)
@@ -188,6 +190,8 @@ void KeypadHandler::releaseKey(const Key &key)
 
 uint16_t KeypadHandler::readKey(const Key &key)
 {
+    Serial.println(key.type == KeyType::HallEffect);
+    Serial.println("1");
     // Perform a digital read if the key is a digital one.
     if (key.type == KeyType::Digital)
     {
@@ -197,8 +201,10 @@ uint16_t KeypadHandler::readKey(const Key &key)
     // Perform an analog read if the key is a hall effect one.
     else if (key.type == KeyType::HallEffect)
     {
+        Serial.println("a");
         // Read the value from the port of the specified key.
         uint16_t value = analogRead(HE_PIN(key.index));
+        Serial.println(value);
 
         // Invert the value if the definition is set since in rare fields of application the sensor
         // is mounted the other way around, resulting in a different polarity and inverted sensor readings.

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -190,8 +190,6 @@ void KeypadHandler::releaseKey(const Key &key)
 
 uint16_t KeypadHandler::readKey(const Key &key)
 {
-    Serial.println(key.type == KeyType::HallEffect);
-    Serial.println("1");
     // Perform a digital read if the key is a digital one.
     if (key.type == KeyType::Digital)
     {
@@ -201,10 +199,8 @@ uint16_t KeypadHandler::readKey(const Key &key)
     // Perform an analog read if the key is a hall effect one.
     else if (key.type == KeyType::HallEffect)
     {
-        Serial.println("a");
         // Read the value from the port of the specified key.
         uint16_t value = analogRead(HE_PIN(key.index));
-        Serial.println(value);
 
         // Invert the value if the definition is set since in rare fields of application the sensor
         // is mounted the other way around, resulting in a different polarity and inverted sensor readings.


### PR DESCRIPTION
Instead of having some massive `getDefaultConfig` function inside `configuration_controller.hpp`, the values are now directly initialized in the struct.

As for the index and key char, that is dynamically assigned on Configuration object initialization, the index is now passed in the constructor of `HEKey` and `DigitalKey`. There, the correct key char is passed to the constructor of `Key`, as well as the index.
This made the function much smaller.

```cpp
Configuration getDefaultConfig()
{
    Configuration config;
     // Populate the hall effect keys array with the correct amount of hall effect keys.
    for (uint8_t i = 0; i < HE_KEYS; i++)
        config.heKeys[i] = HEKey(i);
    
    // Populate the digital keys array with the correct amount of digital keys.
    for (uint8_t i = 0; i < DIGITAL_KEYS; i++)
        config.digitalKeys[i] = DigitalKey(i);

    return config;
};
```

On the `HEKey` and `DigitalKey` structs, a default constructor is necessary in order to perform the following array initialization:
```cpp
// A list of all hall effect key configurations. (rapid trigger, hysteresis, calibration, ...)
HEKey heKeys[HE_KEYS];

// A list of all digital key configurations. (key char, hid state, ...)
DigitalKey digitalKeys[DIGITAL_KEYS];
```
The constructors:
```cpp
DigitalKey() : Key(KeyType::Digital, 0, '\0') {}
HEKey() : Key(KeyType::HallEffect, 0, '\0') {} 
```