### PR TITLE
feat: apply gauss-correction the the sensor values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
         "iosfwd": "cpp",
         "limits": "cpp",
         "streambuf": "cpp",
-        "string_view": "cpp"
+        "string_view": "cpp",
+        "cstdint": "cpp"
     },
     "cmake.configureOnOpen": false
 }

--- a/include/config/configuration.hpp
+++ b/include/config/configuration.hpp
@@ -22,7 +22,7 @@ struct Configuration
     static uint32_t getVersion()
     {
         // Version of the configuration in the format YYMMDDhhmm (e.g. 2301030040 for 12:44am on the 3rd january 2023)
-        int64_t version = 2308130046;
+        int64_t version = 2308151743;
 
         return version;
     }

--- a/include/config/keys/he_key.hpp
+++ b/include/config/keys/he_key.hpp
@@ -32,8 +32,4 @@ struct HEKey : Key
 
     // The value below which the key is no longer pressed and rapid trigger is no longer active in rapid trigger mode.
     uint16_t upperHysteresis = (uint16_t)(TRAVEL_DISTANCE_IN_0_01MM * 0.675);
-
-    // The value read when the keys are in rest position/all the way down.
-    uint16_t restPosition = pow(2, ANALOG_RESOLUTION) - 1; // Set to the outer boundaries in order to make
-    uint16_t downPosition = 0;                             // them overwritable by the calibration code.
 };

--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -26,15 +26,31 @@
 // This value is important to reset the rapid trigger state properly with continuous rapid trigger.
 #define CONTINUOUS_RAPID_TRIGGER_THRESHOLD 10
 
-// This number will be added to the down position and substracted from the rest position on calibration
+// This number will be added to the down position and substracted from the rest position on bounary update
 // to introduce a deadzone at the boundaries. This might be desired since values might fluctuate.
 // e.g. if the value fluctuates around 1970 in rest position but peaks at 1975, this would counteract it.
-// 7 may seem like much at first but when "smashing" the button a lot it'll be just right.
-#define AUTO_CALIBRATION_DEADZONE 10
+// 10 may seem like much at first but when "smashing" the button a lot it'll be just right.
+#define SENSOR_BOUNDARY_DEADZONE 10
 
 // The minimum difference between the rest position and the deadzone-applied down position.
 // It is important to mantain a minimum analog range to prevent "crazy behavior".
-#define AUTO_CALIBRATION_MIN_DISTANCE 200
+#define SENSOR_BOUNDARY_MIN_DISTANCE 200
+
+// Flag for enabling gauss correction. This improves the accuracy of the sensor readings by correcting the curve of
+// the relation between the magnetic field strength near the sensor and the distance of the magnet from the sensor.
+// If this firmware is used on a device with different magnets, the values below have to be adjusted or gauss correction has to be disabled.
+#define USE_GAUSS_CORRECTION_LUT
+
+// Variables for the equation to calculate the ADC reading into a physical distance. These numbers are chosen by trial-and-error, making the curve fit.
+// These values are only effective on magnets like the ones used in the Gateron-KS 20 or the Wooting Lekkers, which are based on them.
+// This gauss correction is also dependent on the hardware specifications. The switch should be as close to the Hall Effect sensor as possible.
+// The Hall Effect sensor used is the 49E sensor, therefore these values are highly tailored towards the hardware of the minipad.
+// If this firmware is used on a device with different magnets/hardware, these values have to be adjusted or gauss correction has to be disabled.
+// The equation for the gauss correction is based off the following Desmos sheet and can be used for adjustments: https://www.desmos.com/calculator/ps4wd127tu
+#define GAUSS_CORRECTION_PARAM_A 6647.8446648
+#define GAUSS_CORRECTION_PARAM_B -0.00609446727442
+#define GAUSS_CORRECTION_PARAM_C -721.743991123
+#define GAUSS_CORRECTION_PARAM_D 4525.58542876
 
 // The resolution for the ADCs on the RP2040. The theoretical maximum value on it is 16 bit (uint16_t).
 #define ANALOG_RESOLUTION 12

--- a/include/handlers/key_states/he_key_state.hpp
+++ b/include/handlers/key_states/he_key_state.hpp
@@ -27,7 +27,7 @@ struct HEKeyState : KeyState
     // specifically mapping future values read from the sensors from this range to 0.01mm steps.
     // By default, set the range from (1<<analog_resolution)-1 to 0 so it can be updated.
     uint16_t restPosition = 0;
-    uint16_t downPosition = 1 << ANALOG_RESOLUTION - 1;
+    uint16_t downPosition = (1 << ANALOG_RESOLUTION) - 1;
 
     // The simple moving average filter for stabilizing the analog outpt.
     SMAFilter filter = SMAFilter(SMA_FILTER_SAMPLE_EXPONENT);

--- a/include/handlers/key_states/he_key_state.hpp
+++ b/include/handlers/key_states/he_key_state.hpp
@@ -15,7 +15,7 @@ struct HEKeyState : KeyState
     bool inRapidTriggerZone = false;
 
     // The current peak value for the rapid trigger logic.
-    uint16_t rapidTriggerPeak = 65535;
+    uint16_t rapidTriggerPeak = UINT16_MAX;
 
     // The last value read from the hall effect sensor.
     uint16_t lastSensorValue = 0;
@@ -25,9 +25,9 @@ struct HEKeyState : KeyState
 
     // The highest and lowest values ever read on the sensor. Used for calibration purposes,
     // specifically mapping future values read from the sensors from this range to 0.01mm steps.
-    // By default, set the range from analog_resolution²-1 to 0 so it can be updated.
+    // By default, set the range from (1<<analog_resolution)-1 to 0 so it can be updated.
     uint16_t restPosition = 0;
-    uint16_t downPosition = 4095;
+    uint16_t downPosition = 1 << ANALOG_RESOLUTION - 1;
 
     // The simple moving average filter for stabilizing the analog outpt.
     SMAFilter filter = SMAFilter(SMA_FILTER_SAMPLE_EXPONENT);

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -28,6 +28,18 @@ public:
     DigitalKeyState digitalKeyStates[DIGITAL_KEYS];
 
 private:
+    const double lutPramA = 6647.8446648;
+    const double lutPramB = -0.00609446727442;
+    const double lutPramC = -721.743991123;
+    const double lutPramD = 4525.58542876;
+    uint16_t lut[1 << ANALOG_RESOLUTION];
+
+    uint16_t adcReadingToDistance(uint16_t adcReading);
+    uint16_t distanceToAdcReading(uint16_t distance);
+    void getSensorOffsets(const Key &key);
+    void applyCalibrationToRawAdcReading(const HEKey &key, uint16_t value);
+    void generate_lut(void);
+    void calibrate(void);
 
     void checkHEKey(const HEKey &key, uint16_t value);
     void checkDigitalKey(const DigitalKey &key, bool pressed);

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -40,6 +40,7 @@ private:
     void generate_lut(void);
     void calibrate(void);
 
+    void updateSensorBoundaries(void);
     void checkHEKey(const HEKey &key, uint16_t value);
     void checkDigitalKey(const DigitalKey &key, bool pressed);
     void pressKey(const Key &key);

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -2,9 +2,10 @@
 #pragma GCC diagnostic ignored "-Wtype-limits"
 
 #include "config/configuration_controller.hpp"
-#include "helpers/sma_filter.hpp"
 #include "handlers/key_states/he_key_state.hpp"
 #include "handlers/key_states/digital_key_state.hpp"
+#include "helpers/sma_filter.hpp"
+#include "helpers/gauss_lut.hpp"
 #include "definitions.hpp"
 
 inline class KeypadHandler
@@ -27,24 +28,15 @@ public:
     DigitalKeyState digitalKeyStates[DIGITAL_KEYS];
 
 private:
-    const double lutPramA = 6647.8446648;
-    const double lutPramB = -0.00609446727442;
-    const double lutPramC = -721.743991123;
-    const double lutPramD = 4525.58542876;
-    uint16_t lut[1 << ANALOG_RESOLUTION];
-
-    uint16_t adcReadingToDistance(uint16_t adcReading);
-    uint16_t distanceToAdcReading(uint16_t distance);
-    void getSensorOffsets(const Key &key);
-    void applyCalibrationToRawAdcReading(const HEKey &key, uint16_t value);
-    void generate_lut(void);
-    void calibrate(void);
-
     void updateSensorBoundaries(const HEKey &key, uint16_t value);
     void checkHEKey(const HEKey &key, uint16_t value);
     void checkDigitalKey(const DigitalKey &key, bool pressed);
     void pressKey(const Key &key);
     void releaseKey(const Key &key);
     uint16_t readKey(const Key &key);
-    uint16_t mapSensorValueToTravelDistance(const HEKey &key, uint16_t value) const;
+    uint16_t adcToDistance(const HEKey &key, uint16_t value);
+
+#ifdef USE_GAUSS_CORRECTION_LUT
+    GaussLUT gaussLUT = GaussLUT(GAUSS_CORRECTION_PARAM_A, GAUSS_CORRECTION_PARAM_B, GAUSS_CORRECTION_PARAM_C, GAUSS_CORRECTION_PARAM_D);
+#endif
 } KeypadHandler;

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -40,7 +40,7 @@ private:
     void generate_lut(void);
     void calibrate(void);
 
-    void updateSensorBoundaries(void);
+    void updateSensorBoundaries(const HEKey &key, uint16_t value);
     void checkHEKey(const HEKey &key, uint16_t value);
     void checkDigitalKey(const DigitalKey &key, bool pressed);
     void pressKey(const Key &key);

--- a/include/handlers/keypad_handler.hpp
+++ b/include/handlers/keypad_handler.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#pragma GCC diagnostic ignored "-Wtype-limits"
 
 #include "config/configuration_controller.hpp"
 #include "helpers/sma_filter.hpp"
@@ -16,9 +17,7 @@ public:
             heKeyStates[i] = HEKeyState();
 
         // Initialize the digital key states with their default values.
-#pragma GCC diagnostic ignored "-Wtype-limits"
         for (uint8_t i = 0; i < DIGITAL_KEYS; i++)
-#pragma GCC diagnostic pop
             digitalKeyStates[i] = DigitalKeyState();
     }
 

--- a/include/helpers/gauss_lut.hpp
+++ b/include/helpers/gauss_lut.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include "definitions.hpp"
+
+class GaussLUT
+{
+public:
+    // Variables for the equation to calculate the ADC reading into a physical distance.
+    // a = y-stretch, b = x-stretch, c = x-offset, d = y-offset, for more info: https://www.desmos.com/calculator/ps4wd127tu
+    GaussLUT(double a, double b, double c, double d);
+
+    uint16_t adcToDistance(const uint16_t adc, uint16_t const restPosition);
+
+private:
+    // The calculated lookup table used by this GaussLUT instance.
+    uint16_t lut[1 << ANALOG_RESOLUTION];
+
+    // The rest position of the keys according to the lookup table.
+    uint16_t lutRestPosition;
+};

--- a/include/helpers/sma_filter.hpp
+++ b/include/helpers/sma_filter.hpp
@@ -5,8 +5,6 @@
 class SMAFilter
 {
 public:
-    SMAFilter() {}
-
     // Initialize the SMAFilter instance with the specified sample exponent.
     // (1 = 1 sample, 2 = 4 samples, 3 = 8 samples, ...)
     SMAFilter(uint8_t samplesExponent)

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -80,7 +80,7 @@ void KeypadHandler::handle()
 
         // Make sure to run checks on the boundaries of the sensors, updating them if available.
         // This is used for calibration by keeping track of the lowest and highest value reached on each key.
-        updateKeyBoundaries(key, value);
+        updateSensorBoundaries(key, value);
 
         // Run the checks on the HE key.
         checkHEKey(key, heKeyStates[key.index].lastMappedValue);
@@ -100,7 +100,7 @@ void KeypadHandler::handle()
     Keyboard.sendReport();
 }
 
-void KeypadHandler::updateKeyBoundaries(const HEKey &key, uint16_t value)
+void KeypadHandler::updateSensorBoundaries(const HEKey &key, uint16_t value)
 {
     // Calculate the value with the deadzone in the positive and negative direction applied.
     uint16_t upperValue = value - AUTO_CALIBRATION_DEADZONE;

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -78,8 +78,9 @@ void KeypadHandler::handle()
         if (!heKeyStates[key.index].filter.initialized)
             continue;
 
-        // Make sure to run checks on the calibration values, updating them if available.
-        calibrate(key, value);
+        // Make sure to run checks on the boundaries of the sensors, updating them if available.
+        // This is used for calibration by keeping track of the lowest and highest value reached on each key.
+        updateKeyBoundaries(key, value);
 
         // Run the checks on the HE key.
         checkHEKey(key, heKeyStates[key.index].lastMappedValue);
@@ -99,7 +100,7 @@ void KeypadHandler::handle()
     Keyboard.sendReport();
 }
 
-void KeypadHandler::calibrate(const HEKey &key, uint16_t value)
+void KeypadHandler::updateKeyBoundaries(const HEKey &key, uint16_t value)
 {
     // Calculate the value with the deadzone in the positive and negative direction applied.
     uint16_t upperValue = value - AUTO_CALIBRATION_DEADZONE;

--- a/src/handlers/keypad_handler.cpp
+++ b/src/handlers/keypad_handler.cpp
@@ -252,7 +252,10 @@ uint16_t KeypadHandler::adcToDistance(const HEKey &key, uint16_t value)
         // If gauss correction is enabled, use the GaussLUT instance to get the distance based on the adc value and the rest position
         // of the key, which is used to determine the offset from the "ideal" rest position set by the lookup table calculations.
 #ifdef USE_GAUSS_CORRECTION_LUT
-        return TRAVEL_DISTANCE_IN_0_01MM - gaussLUT.adcToDistance(value, heKeyStates[key.index].restPosition);
+        uint16_t distance = gaussLUT.adcToDistance(value, heKeyStates[key.index].restPosition);
+
+        distance = distance * TRAVEL_DISTANCE_IN_0_01MM / gaussLUT.adcToDistance(heKeyStates[key.index].downPosition, heKeyStates[key.index].restPosition);
+        return TRAVEL_DISTANCE_IN_0_01MM - constrain(distance, 0, 400);
 #else
     // Map the value with the down and rest position values to a range between 0 and TRAVEL_DISTANCE_IN_0_01MM and constrain it.
     // This is done to guarantee that the unit for the numbers used across the firmware actually matches the milimeter metric.

--- a/src/helpers/gauss_lut.cpp
+++ b/src/helpers/gauss_lut.cpp
@@ -16,7 +16,7 @@ GaussLUT::GaussLUT(double a, double b, double c, double d)
 uint16_t GaussLUT::adcToDistance(const uint16_t adc, const uint16_t restPosition)
 {
     // Get the offset by the difference between the "ideal" rest position of the LUT and the one of the sensor.
-    uint16_t offset = lutRestPosition - restPosition;
+    int16_t offset = lutRestPosition - restPosition;
 
     // Return the value at the index of the adc value, shifted by the offset determined above.
     return lut[adc + offset];

--- a/src/helpers/gauss_lut.cpp
+++ b/src/helpers/gauss_lut.cpp
@@ -1,0 +1,23 @@
+#include <Arduino.h>
+#include "helpers/gauss_lut.hpp"
+#include "definitions.hpp"
+
+GaussLUT::GaussLUT(double a, double b, double c, double d)
+{
+    // Fill the range from a to d in the LUT based on the parameters and the equation. (See:https://www.desmos.com/calculator/ps4wd127tu)
+    // This calculates the "ideal" distance based on the relevant ADC range, being from a to d, since everything above a - d will equal to 0, anyways.
+    for (uint16_t i = 0; i < a - d; i++)
+            lut[i] = constrain(((log(1 - ((i + d) / a)) / -b) - c), 0, TRAVEL_DISTANCE_IN_0_01MM);
+
+    // Calculate the "ideal" rest position of the LUT to calculate offsets on real-based rest positions later on.
+    lutRestPosition = a * (1 - exp(-b * c)) - d;
+}
+
+uint16_t GaussLUT::adcToDistance(const uint16_t adc, const uint16_t restPosition)
+{
+    // Get the offset by the difference between the "ideal" rest position of the LUT and the one of the sensor.
+    uint16_t offset = lutRestPosition - restPosition;
+
+    // Return the value at the index of the adc value, shifted by the offset determined above.
+    return lut[adc + offset];
+}


### PR DESCRIPTION
(Description written by @minisbett)
Adds proper gauss-correction due to the nature of magnetic field strength not being in a linear relation with the distance of the magnet.

The gauss correction is based on 4 parameters approximating a curve taken from the sensors using a 3D printer for accurate measurement. The base for this can be found here: https://www.desmos.com/calculator/ps4wd127tu

Important to know is that by default these values are fully dependent on KS-20 switches being used on the hardware. If this is not the case, you may do tests yourself and modify the parameters properly for a correct gauss-correction.

The class `GaussLUT` has been added which is responsible for generating an LUT upon initialization of it using the parameters.
That LUT is then used as an ideal representation of the ADC <-> magnet distance mapping. This LUT is then shifted, depending on how much the ideal rest position of the keys is from the actual rest position. More on this topic can be found here:
https://github.com/minipadKB/minipad-firmware/pull/55/files#diff-3bda1c153796e2d55a7a79c2e7006e3cd0c24371c360edf65218f9d1ffafa600R5
https://github.com/minipadKB/minipad-firmware/pull/55/files#diff-30e8c046949a262a93004499de6159bc84914f801a5d0b31a4707465e7992a4dR250
https://github.com/minipadKB/minipad-firmware/pull/55/files#diff-5187b98bc558ba45dfad3438f108aa1b719e2980128d6bf40d8f46694894e73eR44