### PR TITLE
feat.: Properly implement digital key support

### DIFF
--- a/include/definitions.hpp
+++ b/include/definitions.hpp
@@ -82,8 +82,9 @@
 // NOTE: By the RP2040, the amount of analog pins (and therefore keys) is limited o 4.
 #define HE_PIN(index) A0 + HE_KEYS - index - 1
 
-// Macro for getting the pin of the specified index of the digital key. The pin order is not swapped here, meaning
-// the first digital key is on pin 0, the second on 1, and so on.
+// Macro for getting the pin of the specified index of the digital key. The pin order is swapped here, meaning
+// the first digital key is on DIGITAL_KEYS - 1, the second on DIGITAL_KEYS - 2, and so on.
+// For 3 digital keys, this would mean that the keys 1, 2 and 3 are bound to the pins 2, 1 and 0 respectively.
 // NOTE: This way, the amount of keys is limited to 26 since the 27th key overlaps with the first analog port, 26.
 #define DIGITAL_PIN(index) 0 + DIGITAL_KEYS - index - 1
 

--- a/include/handlers/keys/digital_key.hpp
+++ b/include/handlers/keys/digital_key.hpp
@@ -21,6 +21,6 @@ struct DigitalKey : Key
     // The last time a key press on the digital key was sent, in milliseconds since firmware bootup.
     unsigned long lastDebounce = 0;
 
-    // Bool whether the pin status on the key is currently HIGH.
-    bool isHigh;
+    // Bool whether the key is currently considered pressed, ignoring any debouncing and only considering the current digital signal.
+    bool pressed;
 };

--- a/src/handlers/key_handler.cpp
+++ b/src/handlers/key_handler.cpp
@@ -148,8 +148,8 @@ void KeyHandler::scanHEKey(HEKey &key)
 
 void KeyHandler::scanDigitalKey(DigitalKey &key)
 {
-    // Read the digital key and save the pin status in the key.
-    key.isHigh = digitalRead(DIGITAL_PIN(key.index)) == PinStatus::HIGH;
+    // Read the digital key and consider it pressed if the pin status is LOW (because of PULLUP).
+    key.pressed = digitalRead(DIGITAL_PIN(key.index)) == PinStatus::LOW;
 }
 
 void KeyHandler::checkHEKey(HEKey &key)
@@ -207,15 +207,15 @@ void KeyHandler::checkHEKey(HEKey &key)
 
 void KeyHandler::checkDigitalKey(DigitalKey &key)
 {
-    // Check whether the pin status on the key is HIGH and the key is fully debounced.
-    if (key.isHigh && millis() - key.lastDebounce >= DIGITAL_DEBOUNCE_DELAY)
+    // Check whether the key is pressed and debounced.
+    if (key.pressed && millis() - key.lastDebounce >= DIGITAL_DEBOUNCE_DELAY)
     {
         // Set the key to pressed and update the last debounce time.
         setPressedState(key, true);
         key.lastDebounce = millis();
     }
     // If the key is not pressed, just set it to unpressed.
-    else if (!key.isHigh)
+    else if (!key.pressed)
         setPressedState(key, false);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,10 @@ void setup()
     // Set the amount of bits for the ADC to the defined one for a better resolution on the analog readings.
     analogReadResolution(ANALOG_RESOLUTION);
 
+    // Set the pinmode for all pins with digital buttons connected to PULLUP, as that's the standard for working with digital buttons.
+    for(int i = 0; i < DIGITAL_KEYS; i++)
+        pinMode(DIGITAL_PIN(i), INPUT_PULLUP);
+
     // Allows to boot into UF2 bootloader mode by pressing the reset button twice.
     rp2040.enableDoubleResetBootloader();
 }


### PR DESCRIPTION
Until now, the implementation of digital keys has been poorly as there was no `INPUT_PULLUP` on the pins by default, which is annoying to users of the firmware as in almost all cases this is required for mechanical switches or simple push buttons to work.

This PR changes the behavior to 1. set the pinmode to `INPUT_PULLUP` on all pins with digital keys and 2. consider `LOW` as the pressed state instead of `HIGH`, as the pull-up invertes the logic. 